### PR TITLE
A few fixes for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ link_directories(${LIBFFI_LIBRARY_PATH})
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_h} ${${PROJECT_NAME}_c})
 
-target_link_libraries(${PROJECT_NAME} ffi)
+target_link_libraries(${PROJECT_NAME} ffi m)
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/shared/shared.h
+++ b/shared/shared.h
@@ -86,8 +86,8 @@ EXPORT bool file_existsQMARK(char *filename) {
   return result;
 }
 
-EXPORT int inc(x) { return x + 1; }
-EXPORT int dec(x) { return x - 1; }
+EXPORT int inc(int x) { return x + 1; }
+EXPORT int dec(int x) { return x - 1; }
 
 EXPORT void async(void *f) {
   //printf("Async starting.\n");

--- a/shared/shared.h
+++ b/shared/shared.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,7 @@
 #include "eval.h"
 #include "gc.h"
 #include <stdio.h>
+#include <unistd.h>
 
 #define HANDLE_SIGNALS 0
 


### PR DESCRIPTION
These changes get a little bit closer to compiling on Linux.

However, linking still fails:

```
$ make
[  5%] Linking C executable ../bin/carp-repl
CMakeFiles/carp-repl.dir/src/primops.c.o: In function `p_now':
primops.c:(.text+0x42ca): undefined reference to `carp_millitime'
CMakeFiles/carp-repl.dir/src/primops.c.o: In function `p_load_dylib':
primops.c:(.text+0x46e9): undefined reference to `carp_load_library'
primops.c:(.text+0x4749): undefined reference to `carp_get_load_library_error'
CMakeFiles/carp-repl.dir/src/primops.c.o: In function `p_unload_dylib':
primops.c:(.text+0x4847): undefined reference to `carp_unload_library'
primops.c:(.text+0x485a): undefined reference to `carp_get_load_library_error'
CMakeFiles/carp-repl.dir/src/primops.c.o: In function `p_register':
primops.c:(.text+0x53c5): undefined reference to `carp_find_symbol'
CMakeFiles/carp-repl.dir/src/primops.c.o: In function `p_register_variable':
primops.c:(.text+0x551d): undefined reference to `carp_find_symbol'
CMakeFiles/carp-repl.dir/src/primops.c.o: In function `p_register_builtin':
primops.c:(.text+0x5645): undefined reference to `carp_find_symbol'
CMakeFiles/carp-repl.dir/src/main.c.o: In function `async':
main.c:(.text+0x25c): undefined reference to `carp_thread_create'
main.c:(.text+0x26c): undefined reference to `carp_thread_destroy'
CMakeFiles/carp-repl.dir/src/main.c.o: In function `platform':
main.c:(.text+0x3b4): undefined reference to `carp_get_platform'
CMakeFiles/carp-repl.dir/src/main.c.o: In function `main':
main.c:(.text+0x679): undefined reference to `carp_platform_init'
main.c:(.text+0x74e): undefined reference to `carp_platform_shutdown'
collect2: error: ld returned 1 exit status
CMakeFiles/carp-repl.dir/build.make:484: recipe for target '../bin/carp-repl' failed
make[2]: *** [../bin/carp-repl] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/carp-repl.dir/all' failed
make[1]: *** [CMakeFiles/carp-repl.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```