### PR TITLE
added some fixes so that carp compiles for linux and spin runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ set(LIBFFI_LIBRARY_PATH
   PATH
   "libffi library directory")
 
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
+endif()
+
 set(SOURCE_DIR src)
 include(globfiles.cmake)
 
@@ -27,7 +32,7 @@ link_directories(${LIBFFI_LIBRARY_PATH})
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_h} ${${PROJECT_NAME}_c})
 
-target_link_libraries(${PROJECT_NAME} ffi)
+target_link_libraries(${PROJECT_NAME} ffi m c pthread dl)
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/lisp/cc.carp
+++ b/lisp/cc.carp
@@ -27,12 +27,17 @@
 (defn lib-paths ()
   (if (windows?)
     ""
-    (str (:linkdir-flag platform-specifics) "/usr/local/lib/ -lglfw3")))
+    (str (:linkdir-flag platform-specifics) "/usr/local/lib/ -lglfw")))
+
+;; (defn framework-paths ()
+;;   (if (windows?)
+;;     ""
+;;     "-framework OpenGL -framework Cocoa -framework IOKit"))
 
 (defn framework-paths ()
-  (if (windows?)
-    ""
-    "-framework OpenGL -framework Cocoa -framework IOKit"))
+  (if (or (windows?) (linux?))
+      ""
+      "-framework OpenGL -framework Cocoa -framework IOKit"))
 
 (defn print-external-compiler-time [start-time func-name]
   (let [t (/ (itof (- (now) start-time)) 1000f)]
@@ -56,7 +61,7 @@
   (let [clang-command (str "clang -g -DAPI= "
                            (if exe
                              (str "-o " exe-out-dir exe-name " ")
-                             (str "-shared -g -o " out-dir c-func-name ".so "))
+                             (str "-shared -fPIC -D_GNU_SOURCE -g -o " out-dir c-func-name ".so "))
                            c-file-name " "
                            (include-paths)  " "
                            (lib-paths) " "

--- a/lisp/gl.carp
+++ b/lisp/gl.carp
@@ -1,5 +1,8 @@
 
-(def glfw (load-dylib "libglfw3.dylib"))
+(if (osx?) (def *LIBNAME* "libglfw3.dylib") "")
+(if (linux?) (def *LIBNAME* "libglfw.so") "")
+
+(def glfw (load-dylib *LIBNAME*))
 
 (reset! extra-header-deps (cons "<GLFW/glfw3.h>" extra-header-deps))
 

--- a/shared/platform.h
+++ b/shared/platform.h
@@ -2,7 +2,8 @@
 
 #include "types.h"
 
-#ifdef __APPLE__
+
+#if defined (__APPLE__) || defined(__linux__)
 
 #include <stdlib.h>
 #include <assert.h>
@@ -91,7 +92,14 @@ char* carp_get_load_library_error() {
 }
 
 CARP_PLATFORM carp_get_platform() {
+#ifdef __APPLE__
 	return CARP_PLATFORM_OSX;
+#elif defined __linux__
+	return CARP_PLATFORM_LINUX;
+#elif defined WIN32
+	return CARP_PLATFORM_WINDOWS;
+#endif
+	return CARP_PLATFORM_UNKNOWN;
 }
 
 #endif // __APPLE__


### PR DESCRIPTION
The lastest version would fail to compile on Linux, but with a few tweaks, as you can see in the pull request, it runs now. We should then add / mention in the Installation manual, that for Linux clang must be installed. This isn't the default compiler as it is for OSX.