### PR TITLE
updating cmake libffi to use pkg-config - now builds under linux cleanly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,25 @@ set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
+
+    # linux uses pkg config
+    Include(FindPkgConfig)
+    PKG_SEARCH_MODULE(LIBFFI REQUIRED libffi)
+else()
+    # other systems use manually set paths
+    # set name must match the one set by pkg config
+    set(LIBFFI_INCLUDE_DIRS
+      "${PROJECT_SOURCE_DIR}/../libffi/x86_64-apple-darwin15.3.0/include"
+      CACHE
+      PATH
+      "libffi include directory")
+
+    # set name must match the one set by pkg config
+     set(LIBFFI_LIBRARIES
+      "${PROJECT_SOURCE_DIR}/../libffi/x86_64-apple-darwin15.3.0/.libs"
+      CACHE
+      PATH
+      "libffi library directory")
 endif()
 
 set(SOURCE_DIR src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,32 +7,30 @@ set(VERSION_MINOR "0")
 set(VERSION_PATCH "1")
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
-set(LIBFFI_INCLUDE_PATH
-  "${PROJECT_SOURCE_DIR}/../libffi/x86_64-apple-darwin15.3.0/include"
-  CACHE
-  PATH
-  "libffi include directory")
-
-set(LIBFFI_LIBRARY_PATH
-  "${PROJECT_SOURCE_DIR}/../libffi/x86_64-apple-darwin15.3.0/.libs"
-  CACHE
-  PATH
-  "libffi library directory")
-
-
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
 endif()
 
 set(SOURCE_DIR src)
 include(globfiles.cmake)
 
-include_directories(${LIBFFI_INCLUDE_PATH})
-link_directories(${LIBFFI_LIBRARY_PATH})
+include(FindPkgConfig)
+PKG_SEARCH_MODULE(LIBFFI REQUIRED libffi)
+
+include_directories(
+    ${LIBFFI_INCLUDE_DIRS})
+
+link_directories(
+    ${LIBFFI_LIBRARIES})
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_h} ${${PROJECT_NAME}_c})
 
-target_link_libraries(${PROJECT_NAME} ffi m c pthread dl)
+target_link_libraries(${PROJECT_NAME}
+    ${LIBFFI_LIBRARIES}
+    m
+    c
+    pthread
+    dl)
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,7 @@ Add the 'bin' directory to your path to enable calling the ```carp``` command. T
 ```export PATH=$PATH:~/Carp/bin/```
 
 Carp is developed on OSX 10.10 but Linux works too. More platforms are coming soon, Windows is being worked on. There are a few dependencies that have to be installed:
+ * pkg-config
  * libffi
  * glfw3
  * rlwrap


### PR DESCRIPTION
The previous cmake included hard-coded paths to libffi which looked like paths on a mac.

This pkg-config version should work on any system as long as 'pkg-config' is installed and working correctly.

What are your thoughts?