### PR TITLE
macports: avoid dylib/link confusion

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,12 +17,16 @@ Tip: Build libffi with ```./configure --enable-static --disable-shared``` to avo
 
 You will have to tell cmake the location of 'libffi' before it can build correctly. Try using their GUI application if you have trouble, it's pretty self explanatory (first press 'Configure', then set up the paths to 'libffi', and then press 'Generate').
 
-To make cmake find libffi you might need to add it to the PKG_CONFIG_PATH:
+To make cmake find libffi you might need to add it to the `PKG_CONFIG_PATH`:
 ```
 export PKG_CONFIG_PATH=../libffi/<ARCHITECTURE>/
 ```
 
-And to be able to run 'make' you might need to add libffi to your C_INCLUDE_PATH:
+And to be able to run 'make' you might need to add libffi to your `C_INCLUDE_PATH`:
+```
+cmake . cmake . -DLIBFFI_INCLUDE_PATH=/opt/local/lib/libffi-3.2.1/include -DLIBFFI_LIBRARY_PATH=/opt/local/lib/
+```
+or
 ```
 export C_INCLUDE_PATH=../libffi/<ARCHITECTURE>/include
 ```
@@ -33,6 +37,7 @@ Note: 'rlwrap' is not strictly needed but makes the REPL experience much nicer, 
 
 ## Mac OS X
 If 'libffi' is installed with Brew, you can find the libraries at "/usr/local/Cellar/libffi/3.0.13/lib/" and the include files at "/usr/local/opt/libffi/lib/libffi-3.0.13/include".
+With macports 'libffi' is at "/opt/local/lib/libffi-3.2.1/include" and "/opt/local/lib".
 
 ## Linux
 On Linux Clang must be installed (GCC support will be added later).

--- a/bin/carp
+++ b/bin/carp
@@ -7,4 +7,4 @@ WRAPPER=rlwrap
 #WRAPPER=lldb
 #WRAPPER=valgrind
 
-CARP_DIR=$DIR/../ $WRAPPER $DIR/carp-repl $1
+CARP_DIR=$DIR/../ $WRAPPER $DIR/carp-repl $@

--- a/lisp/cc.carp
+++ b/lisp/cc.carp
@@ -13,21 +13,29 @@
      :link-extension ".lib"
      :include-flag "/I"
      :linkdir-flag "/link /NOLOGO /LIBPATH:"}
-    {:dylib-extension ".so"
+    (if (osx?)
+     {:dylib-extension ".dylib"
+     :link-extension ".bundle"
+     :include-flag "-I"
+     :linkdir-flag "-L"}
+     {:dylib-extension ".so"
      :link-extension ".so"
      :include-flag "-I"
-     :linkdir-flag "-L"}))
+     :linkdir-flag "-L"})))
 
 (defn link-libs (dependencies)
-  (join " " (map (fn (f) (str out-dir (c-ify-name (str f)) (:link-extension platform-specifics))) dependencies)))
+  (join " " (map (fn (f) (str out-dir (c-ify-name (str f))
+                              (:link-extension platform-specifics))) dependencies)))
 
 (defn include-paths ()
-  (str (:include-flag platform-specifics) "/usr/local/include " (:include-flag platform-specifics) carp-dir "/shared"))
+  (str (:include-flag platform-specifics) "/usr/local/include "
+       (:include-flag platform-specifics) "/opt/local/include "
+       (:include-flag platform-specifics) carp-dir "/shared"))
 
 (defn lib-paths ()
   (cond
       (windows?) ""
-      (osx?)     (str (:linkdir-flag platform-specifics) "/usr/local/lib/ -lglfw3")
+      (osx?)     (str (:linkdir-flag platform-specifics) "/usr/local/lib/ -L/opt/local/lib/ -lglfw")
       (linux?)   (str (:linkdir-flag platform-specifics) "/usr/local/lib/ -lglfw")))
 
 (defn framework-paths ()
@@ -57,7 +65,8 @@
   (let [clang-command (str "clang -g -DAPI= "
                            (if exe
                              (str "-o " exe-out-dir exe-name " ")
-                             (str "-shared -fPIC -D_GNU_SOURCE -g -o " out-dir c-func-name ".so "))
+                             (str "-shared -fPIC -D_GNU_SOURCE -g -o " out-dir c-func-name
+                                  (:link-extension platform-specifics) " "))
                            c-file-name " "
                            (include-paths)  " "
                            (lib-paths) " "
@@ -95,6 +104,8 @@
       (system "del *.obj"))
     (do
       (system "rm declarations.h")
-      (system "rm *.so")
+      (system (str "rm *" (:link-extension platform-specifics)))
       (system "rm *.c")
-      (system "rm -r *.dSYM"))))
+      (if (osx?)
+        (system "rm -r *.dSYM"))
+      )))

--- a/lisp/compiler.carp
+++ b/lisp/compiler.carp
@@ -132,7 +132,7 @@
 (defn compiler/bake-group [group-name code-nodes deps]
   (let [src (with-declarations-header (join "\n\n" (map (fn [d] (:src d)) code-nodes)))
         c-file-name (c-ify-name (str out-dir group-name ".c"))
-        dylib-full-path (c-ify-name (str out-dir group-name (:dylib-extension platform-specifics)))]
+        dylib-full-path (c-ify-name (str out-dir group-name (:link-extension platform-specifics)))]
     (do
       ;;(println (str "Compiling group '" group-name "'."))
       (def src src)

--- a/lisp/gl.carp
+++ b/lisp/gl.carp
@@ -1,6 +1,7 @@
 
-(if (osx?) (def *LIBNAME* "libglfw3.dylib") "")
-(if (linux?) (def *LIBNAME* "libglfw.so") "")
+;(if (osx?) (def *LIBNAME* "libglfw3.dylib") "")
+;(if (linux?) (def *LIBNAME* "libglfw.so") "")
+(def *LIBNAME* (str (if (windows?) "" "lib") "glfw" (:dylib-extension platform-specifics))
 
 (def glfw (load-dylib *LIBNAME*))
 


### PR DESCRIPTION
use true bundle/dylib extensions, avoid mixup, avoid hardcoded .so,
add -L/opt/local/lib -I/opt/local/include search paths for macports,
use libglfw.dylib, not libglfw3.dylib

not necesserily to be merged, but this is what I needed