### PR TITLE
adding blank lines in RESEARCH.md for better markdown formatting

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1,70 +1,82 @@
 https://news.ycombinator.com/item?id=12039268
 
 # C PROGRAMMING, LLVM, AND DEBUGGING
-http://clang.llvm.org/docs/AddressSanitizer.html
-https://www.iar.com/support/resources/articles/advanced-preprocessor-tips-and-tricks/
-http://jvns.ca/blog/2016/03/01/a-few-notes-on-the-stack/
-https://www.recurse.com/blog/7-understanding-c-by-learning-assembly
-http://msm.runhello.com/p/1003
-http://stackoverflow.com/questions/2505385/classes-and-static-variables-in-shared-libraries
-http://www.gameaipro.com/GameAIPro/GameAIPro_Chapter15_Runtime_Compiled_C++_for_Rapid_AI_Development.pdf
-https://fsharpforfunandprofit.com/posts/fsharp-decompiled/
-http://kristerw.blogspot.se/2016/05/type-based-aliasing-in-c.html
+
+- http://clang.llvm.org/docs/AddressSanitizer.html
+- https://www.iar.com/support/resources/articles/advanced-preprocessor-tips-and-tricks/
+- http://jvns.ca/blog/2016/03/01/a-few-notes-on-the-stack/
+- https://www.recurse.com/blog/7-understanding-c-by-learning-assembly
+- http://msm.runhello.com/p/1003
+- http://stackoverflow.com/questions/2505385/classes-and-static-variables-in-shared-libraries
+- http://www.gameaipro.com/GameAIPro/GameAIPro_Chapter15_Runtime_Compiled_C++_for_Rapid_AI_Development.pdf
+- https://fsharpforfunandprofit.com/posts/fsharp-decompiled/
+- http://kristerw.blogspot.se/2016/05/type-based-aliasing-in-c.html
 
 # OWNERSHIP & BORROWING
-http://blog.piston.rs/2016/01/23/dynamo/
-http://evincarofautumn.blogspot.se/2016/01/thoughts-on-using-fractional-types-to.html
-http://andrewbrinker.github.io/blog/2016/03/27/string-types-in-rust/
-http://www.pipeline.com/~hbaker1/LinearLisp.html
-http://smallcultfollowing.com/babysteps/blog/2016/04/27/non-lexical-lifetimes-introduction/
-https://doc.rust-lang.org/book/deref-coercions.html
-http://ticki.github.io/blog/lambda_crabs_1/
+
+- http://blog.piston.rs/2016/01/23/dynamo/
+- http://evincarofautumn.blogspot.se/2016/01/thoughts-on-using-fractional-types-to.html
+- http://andrewbrinker.github.io/blog/2016/03/27/string-types-in-rust/
+- http://www.pipeline.com/~hbaker1/LinearLisp.html
+- http://smallcultfollowing.com/babysteps/blog/2016/04/27/non-lexical-lifetimes-introduction/
+- https://doc.rust-lang.org/book/deref-coercions.html
+- http://ticki.github.io/blog/lambda_crabs_1/
 
 # MODULES & FUNCTORS
-http://homepages.inf.ed.ac.uk/mfourman/teaching/mlCourse/notes/sml-modules.html
-https://www.cse.unsw.edu.au/~chak/papers/modules-classes.pdf
+
+- http://homepages.inf.ed.ac.uk/mfourman/teaching/mlCourse/notes/sml-modules.html
+- https://www.cse.unsw.edu.au/~chak/papers/modules-classes.pdf
 
 # TYPES
-https://lambdacube3d.wordpress.com/2016/03/03/tuples-as-heterogeneous-lists/
-https://jeltsch.wordpress.com/2016/02/22/generic-programming-in-haskell/
-http://okmij.org/ftp/ML/generalization.html
-http://www.cs.cornell.edu/courses/cs312/2005sp/lectures/rec22.asp
-http://www.cs.cornell.edu/courses/cs3110/2011sp/lectures/lec26-type-inference/type-inference.htm
-http://www.scheme.com/tspl4/examples.html#./examples:h10
+
+- https://lambdacube3d.wordpress.com/2016/03/03/tuples-as-heterogeneous-lists/
+- https://jeltsch.wordpress.com/2016/02/22/generic-programming-in-haskell/
+- http://okmij.org/ftp/ML/generalization.html
+- http://www.cs.cornell.edu/courses/cs312/2005sp/lectures/rec22.asp
+- http://www.cs.cornell.edu/courses/cs3110/2011sp/lectures/lec26-type-inference/type-inference.htm
+- http://www.scheme.com/tspl4/examples.html#./examples:h10
 
 # CSP
-http://reaktor.com/blog/why-csp-matters-ii-how-do-i-know-sync-works/
+
+- http://reaktor.com/blog/why-csp-matters-ii-how-do-i-know-sync-works/
 
 # GC
-http://prl.ccs.neu.edu/blog/2016/05/24/measuring-gc-latencies-in-haskell-ocaml-racket/
+
+- http://prl.ccs.neu.edu/blog/2016/05/24/measuring-gc-latencies-in-haskell-ocaml-racket/
 
 # OTHER LANGUAGES
-https://wingolog.org/archives/2016/02/08/a-lambda-is-not-necessarily-a-closure
-http://alex-charlton.com/posts/Prototype_to_polish_Making_games_in_CHICKEN_Scheme_with_Hypergiant/
-http://beautifulracket.com/first-lang.html
-http://stackoverflow.com/questions/4899113/fixed-point-combinator-for-mutually-recursive-functions/5272086#5272086
-http://klisp.org
-http://gliese1337.blogspot.se/2012/04/schrodingers-equation-of-software.html
-https://github.com/kiselgra/c-mera
-https://github.com/wolfgangj/bone-lisp/
-https://github.com/akkartik/mu
-https://github.com/haskell-lisp/liskell
-https://github.com/PistonDevelopers/dyon/pull/318
+
+- https://wingolog.org/archives/2016/02/08/a-lambda-is-not-necessarily-a-closure
+- http://alex-charlton.com/posts/Prototype_to_polish_Making_games_in_CHICKEN_Scheme_with_Hypergiant/
+- http://beautifulracket.com/first-lang.html
+- http://stackoverflow.com/questions/4899113/fixed-point-combinator-for-mutually-recursive-functions/5272086#5272086
+- http://klisp.org
+- http://gliese1337.blogspot.se/2012/04/schrodingers-equation-of-software.html
+- https://github.com/kiselgra/c-mera
+- https://github.com/wolfgangj/bone-lisp/
+- https://github.com/akkartik/mu
+- https://github.com/haskell-lisp/liskell
+- https://github.com/PistonDevelopers/dyon/pull/318
 
 # LANGUAGE DESIGN
-http://www.complang.tuwien.ac.at/kps2015/proceedings/KPS_2015_submission_29.pdf
-http://www.lihaoyi.com/post/WhatsinaBuildTool.html
-http://prog21.dadgum.com/136.html
-https://existentialtype.wordpress.com/2011/03/19/dynamic-languages-are-static-languages/
+
+- http://www.complang.tuwien.ac.at/kps2015/proceedings/KPS_2015_submission_29.pdf
+- http://www.lihaoyi.com/post/WhatsinaBuildTool.html
+- http://prog21.dadgum.com/136.html
+- https://existentialtype.wordpress.com/2011/03/19/dynamic-languages-are-static-languages/
 
 # GRAPHS
-https://en.wikipedia.org/wiki/Strongly_connected_component
-https://en.wikipedia.org/wiki/Transitive_closure#In_graph_theory
+
+- https://en.wikipedia.org/wiki/Strongly_connected_component
+- https://en.wikipedia.org/wiki/Transitive_closure#In_graph_theory
 
 # GRAPHICS
-https://medium.com/@evanwallace/easy-scalable-text-rendering-on-the-gpu-c3f4d782c5ac#.ajyuy8weu
-https://pomax.github.io/bezierinfo/
+
+- https://medium.com/@evanwallace/easy-scalable-text-rendering-on-the-gpu-c3f4d782c5ac#.ajyuy8weu
+- https://pomax.github.io/bezierinfo/
 
 # TO TRY
-let fun ident(x) => x
-in ident(ident)(2) end
+
+- let fun ident(x) => x
+- in ident(ident)(2) end
+


### PR DESCRIPTION
Markdown will squash adjacent lines into a single sentence/paragraph, blank lines between them will prevent this.

See the current formatting of
https://github.com/eriksvedang/Carp/blob/master/RESEARCH.md
which often has multiple links on the same line, and with word-wrapping.

and compare it to
https://github.com/mkfifo/Carp/blob/research-markdown-formatting/RESEARCH.md
which has a single link per line.

We could alternatively add in some html `<br />`, or format it as a mark-down list by prefixing each line with ` -`.
But this proposed solution has the advantage of the file still being easy to treat as plain-text.