### PR TITLE
enable -std=c99 on cmake allowing for GCC linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,3 +43,4 @@ add_custom_target(
     COMMAND find . -iname '*.[ch]' | xargs clang-format -style=file -i
 )
 
+set_property(TARGET carp-repl PROPERTY C_STANDARD 99)


### PR DESCRIPTION
This fixes building Carp on linux with GCC for me, untested if this breaks other platform's builds.