### PR TITLE
Safe(r) mkdir and touch

### DIFF
--- a/lisp/boot.carp
+++ b/lisp/boot.carp
@@ -16,8 +16,8 @@
 (def carp-dev (env-variable-true? (getenv "CARP_DEV")))
 
 ;; ~~~ CORE ~~~
-(load-lisp (str carp-dir "lisp/core.carp"))
 (load-lisp (str carp-dir "lisp/builtins.carp"))
+(load-lisp (str carp-dir "lisp/core.carp"))
 (load-lisp (str carp-dir "lisp/signatures.carp"))
 (load-lisp (str carp-dir "lisp/tester.carp"))
 

--- a/lisp/core.carp
+++ b/lisp/core.carp
@@ -102,6 +102,9 @@
             (reset! result true)))
         result)))
 
+(defn string-contains? [str char]
+  (array-contains? (chars str) char))
+
 (defn any (pred xs)
   (contains? (map pred xs) true))
 

--- a/lisp/core.carp
+++ b/lisp/core.carp
@@ -292,8 +292,22 @@
 (defn ls () (system "ls"))
 (defn pwd () (system "pwd"))
 (defn user () (getenv "USER"))
-(defn mkdir (dir-name) (system (str "mkdir " dir-name)))
-(defn touch (file-name) (system (str "touch " file-name)))
+
+(defn shell-safe? (str)
+  (do
+    (def shell-safe-chars "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-/.")
+    (defn in-shell-safe-chars? (char) (string-contains? shell-safe-chars char))
+
+    (all? in-shell-safe-chars? (chars str))))
+
+(defn mkdir (dir-name)
+  (if (shell-safe? dir-name)
+    (system (str "mkdir " dir-name))
+    (list 'error "invalid dir-name input")))
+(defn touch (file-name)
+  (if (shell-safe? file-name)
+    (system (str "touch " file-name))
+    (list 'error "invalid file-name input")))
 
 (register-builtin "platform" '() :int)
 

--- a/lisp/core_tests.carp
+++ b/lisp/core_tests.carp
@@ -387,6 +387,11 @@
                _ :also-fail)
              27))
 
+(deftest test-string-handling
+  (do
+    (assert (string-contains? "abc" \a))
+    (assert (not (string-contains? "abc" \d)))))
+
 ;; Can't test this inside a function:
 (defn define-at-toplevel ()
   (def top-var :mountain-high))


### PR DESCRIPTION
Attempting to address #33

I have defined a set of characters allowed within mkdir and touch, both will refuse any string which isn't made up entirely of those characters.

I have also changed boot.lisp to load builtins before core, so that core can use builtins in the implementation - I think this makes sense.