### PR TITLE
Fix backslashes in strings in the repl

### DIFF
--- a/src/repl.c
+++ b/src/repl.c
@@ -43,6 +43,9 @@ int paren_balance(char *s) {
         //printf("back from ignoring string\n");
         ignore = '\0';
       }
+      else if(c == '\\' && ignore == '"') {
+        i++;
+      }
       else if(c == '\n' && ignore == ';') {
         //printf("back from ignoring comment\n");
         ignore = '\0';


### PR DESCRIPTION
Something like `(println "test \" test")` compiled fine when the code was in a file, but in the repl, it mistakenly thought that a string was not terminated because it didn't interpret the `\`.

This pull request fixes that issue, and thereby enables one to have a `"` inside a string in the repl.