### PR TITLE
Make mkdir and touch safe and without surprises

### DIFF
--- a/lisp/core.carp
+++ b/lisp/core.carp
@@ -286,11 +286,19 @@
           text
           (map2 list (keys substitutions) (values substitutions))))
 
+(defn shell-quote [arg]
+  (str
+    "\"" ;; surround with quotes
+    (str-replace
+      (str-replace arg "\\" "\\\\") ;; replace backslashes
+      "\"" "\\\"") ;; replace double-quotes
+    "\""))
+
 (defn ls () (system "ls"))
 (defn pwd () (system "pwd"))
 (defn user () (getenv "USER"))
-(defn mkdir (dir-name) (system (str "mkdir " dir-name)))
-(defn touch (file-name) (system (str "touch " file-name)))
+(defn mkdir (dir-name) (system (str "mkdir " (shell-quote dir-name))))
+(defn touch (file-name) (system (str "touch " (shell-quote file-name))))
 
 (register-builtin "platform" '() :int)
 

--- a/lisp/core.carp
+++ b/lisp/core.carp
@@ -288,11 +288,11 @@
 
 (defn shell-quote [arg]
   (str
-    "\"" ;; surround with quotes
+    "'" ;; surround with quotes
     (str-replace
       (str-replace arg "\\" "\\\\") ;; replace backslashes
-      "\"" "\\\"") ;; replace double-quotes
-    "\""))
+      "'" "\\'") ;; replace single quotes
+    "'"))
 
 (defn ls () (system "ls"))
 (defn pwd () (system "pwd"))


### PR DESCRIPTION
This 1. makes mkdir and touch safe against shell injection vulnerabilities,
and 2. still allows the user to create any kind of file or directory.

This would fix my #33 I think.