### PR TITLE
changing boot.lisp order - builtins before core

### DIFF
--- a/lisp/boot.carp
+++ b/lisp/boot.carp
@@ -16,8 +16,8 @@
 (def carp-dev (env-variable-true? (getenv "CARP_DEV")))
 
 ;; ~~~ CORE ~~~
-(load-lisp (str carp-dir "lisp/core.carp"))
 (load-lisp (str carp-dir "lisp/builtins.carp"))
+(load-lisp (str carp-dir "lisp/core.carp"))
 (load-lisp (str carp-dir "lisp/signatures.carp"))
 (load-lisp (str carp-dir "lisp/tester.carp"))
 


### PR DESCRIPTION
Loading builtins before core means that the core.lisp implementation can use builtins.