### PR TITLE
renaming core.any to core.any? to match similar functions (like core.all?)

### DIFF
--- a/lisp/ast.carp
+++ b/lisp/ast.carp
@@ -185,7 +185,7 @@
     (do
       {:node :lookup
        :constructor true
-       :generic (any generic-type? (array-to-list member-types))
+       :generic (any? generic-type? (array-to-list member-types))
        :typevars (typevars-from-member-types member-types)
        :type (list :fn (repeatedly gen-typevar arg-count) (keyword struct-name))
        :member-types member-types

--- a/lisp/compiler_helpers.carp
+++ b/lisp/compiler_helpers.carp
@@ -15,12 +15,12 @@
   (match (type t)
     :string true
     :keyword false
-    :list (any true? (map generic-type? t))
+    :list (any? true? (map generic-type? t))
     x (error (str "Invalid type in 'generic-type?': " (prn x)))))
 
 (defn generic-function? [ast]
   (match (:type ast)
-    (:fn arg-types ret-type) (or (any generic-type? arg-types) (generic-type? ret-type))
+    (:fn arg-types ret-type) (or (any? generic-type? arg-types) (generic-type? ret-type))
     x (error (str "Can't match " x " in generic-function?"))))
 
 (defn c-ify-name [lisp-name]

--- a/lisp/core.carp
+++ b/lisp/core.carp
@@ -102,7 +102,7 @@
 (defn string-contains? [str char]
   (array-contains? (chars str) char))
 
-(defn any (pred xs)
+(defn any? (pred xs)
   ;; short circuit if any (pred item) is true
   (let [cont true
         res  false]

--- a/lisp/core_tests.carp
+++ b/lisp/core_tests.carp
@@ -392,11 +392,11 @@
     (assert (string-contains? "abc" \a))
     (assert (not (string-contains? "abc" \d)))))
 
-(deftest test-any
+(deftest test-any?
   (do
     (defn is-a (x) (= \a x))
-    (assert (any is-a (cons \a (cons \b (cons \c nil)))))
-    (assert (not (any is-a (cons \d (cons \b (cons \c nil))))))))
+    (assert (any? is-a (cons \a (cons \b (cons \c nil)))))
+    (assert (not (any? is-a (cons \d (cons \b (cons \c nil))))))))
 
 (deftest test-all?
   (do

--- a/lisp/structs.carp
+++ b/lisp/structs.carp
@@ -48,7 +48,7 @@
         (map graph/unload-group (set (map :group dependers)))
         ;;(println (str "graph nodes: " (keys graph)))
 
-        (if (any generic-type? (array-to-list member-types))
+        (if (any? generic-type? (array-to-list member-types))
           (do
             (eval (list 'def (symbol struct-name) {:struct true
                                                    :generic true
@@ -105,7 +105,7 @@
 
 (defn struct-type? [t]
   (if (list? t)
-    (any struct-type? t)
+    (any? struct-type? t)
     (let [x (symbol (name t))
           lookup (if (def? x) (eval x) nil)]
       (and (dict? lookup) (key-is-true? lookup :struct)))))


### PR DESCRIPTION
`all?` and `any?` should be named similarly with a `?`.